### PR TITLE
Add new configs to jwt.local.php.dist;

### DIFF
--- a/config/autoload/jwt.local.php
+++ b/config/autoload/jwt.local.php
@@ -1,0 +1,1 @@
+jwt.local.php.dist

--- a/config/autoload/jwt.local.php.dist
+++ b/config/autoload/jwt.local.php.dist
@@ -1,7 +1,10 @@
 <?php
 
 return [
-    'jwt' => [
-        'signing_key' => 'YourSecretKeyForSigningJwts'
-    ]
+    'jwt'                              => [
+        'signing_key'   => 'YourSecretKeyForSigningJwts',
+        'typ'           => 'JWT',
+        'alg'           => 'HS256'
+    ],
+    'access-control'                   => []
 ];

--- a/module/Core/src/Service/JwtService.php
+++ b/module/Core/src/Service/JwtService.php
@@ -19,7 +19,10 @@ class JwtService
     public function generateJwt(User $user)
     {
         $signingKey = $this->getJwtConfig()['signing_key'];
-        $header = json_encode(['typ' => 'JWT', 'alg' => 'HS256']);
+        $header = json_encode([
+            'typ' => $this->getJwtConfig()['typ'],
+            'alg' => $this->getJwtConfig()['alg']
+        ]);
 
         $roles = [];
         foreach($user->getRoles() as $role)


### PR DESCRIPTION
@DLMousey I was working on #2 but as the README.md in config/autoload/ says that it already load all files *.global.php and *.local.php, so there isn't a need to change anything on the factories, just put the info in the local files.
Therefore I created a link from jwt.local.php.dist to jwt.local.php, for it to be loaded, and add some configs there too.